### PR TITLE
转为使用openssl_decrypt。修改封装

### DIFF
--- a/WxpayRefundNotifyHelper.php
+++ b/WxpayRefundNotifyHelper.php
@@ -112,10 +112,13 @@ class WxpayRefundNotifyHelper
 	 */
 	private function _decryptData(string $encryptData, string $md5LowerKey = '')
 	{
+		//1. base64_decode
 		$encryptData_debase64=base64_decode($encryptData);
+		//2. md5 original key
 		if (empty($md5LowerKey)) {
 			$md5LowerKey = strtolower(md5(self::MCH_KEY));
 		}
+		//3. decrypt AES ECB
 		$iv = mcrypt_create_iv(mcrypt_get_iv_size(self::CIPHER, self::MCRYPT_MODE), MCRYPT_RAND);
 		$decrypted = mcrypt_decrypt(self::CIPHER, $md5LowerKey, $encryptData_debase64, self::MCRYPT_MODE, $iv);
 		return $this->xml2array($decrypted);

--- a/WxpayRefundNotifyHelper.php
+++ b/WxpayRefundNotifyHelper.php
@@ -34,7 +34,7 @@ class WxpayRefundNotifyHelper
 			$xml = file_get_contents("php://input");
 			$data = $this->xml2array($xml);
 			$encryptData = $data['req_info'];
-			$decryptedData = $this->_decryptData($encryptData);
+			$decryptedData = $this->xml2array($this->decryptData($encryptData,$this->MCH_KEY));
 			$msg = 'OK';
 			$result = $this->handelInternal($decryptedData, $msg);
 			$returnArray['return_msg'] = $msg;
@@ -110,17 +110,14 @@ class WxpayRefundNotifyHelper
 	 * @param string $md5LowerKey
 	 * @return array
 	 */
-	private function _decryptData(string $encryptData, string $md5LowerKey = '')
+	public function decryptData(string $encryptData, string $Key = '')
 	{
 		//1. base64_decode
-		$encryptData_debase64=base64_decode($encryptData);
+		// openssl_decrypt only accept base64 input param
 		//2. md5 original key
-		if (empty($md5LowerKey)) {
-			$md5LowerKey = strtolower(md5(self::MCH_KEY));
-		}
+		$md5LowerKey = strtolower(md5($Key));
 		//3. decrypt AES ECB
-		$iv = mcrypt_create_iv(mcrypt_get_iv_size(self::CIPHER, self::MCRYPT_MODE), MCRYPT_RAND);
-		$decrypted = mcrypt_decrypt(self::CIPHER, $md5LowerKey, $encryptData_debase64, self::MCRYPT_MODE, $iv);
-		return $this->xml2array($decrypted);
+		$decrypted = openssl_decrypt($encryptData, "AES-256-ECB", $md5LowerKey);
+		return $decrypted;
 	}
 }

--- a/WxpayRefundNotifyHelper.php
+++ b/WxpayRefundNotifyHelper.php
@@ -33,8 +33,8 @@ class WxpayRefundNotifyHelper
 		try {
 			$xml = file_get_contents("php://input");
 			$data = $this->xml2array($xml);
-			$encryptData = base64_decode($data['req_info']);
-			$decryptedData = $this->_decryptAesData($encryptData);
+			$encryptData = $data['req_info'];
+			$decryptedData = $this->_decryptData($encryptData);
 			$msg = 'OK';
 			$result = $this->handelInternal($decryptedData, $msg);
 			$returnArray['return_msg'] = $msg;
@@ -110,13 +110,14 @@ class WxpayRefundNotifyHelper
 	 * @param string $md5LowerKey
 	 * @return array
 	 */
-	private function _decryptAesData(string $encryptData, string $md5LowerKey = '')
+	private function _decryptData(string $encryptData, string $md5LowerKey = '')
 	{
+		$encryptData_debase64=base64_decode($encryptData);
 		if (empty($md5LowerKey)) {
 			$md5LowerKey = strtolower(md5(self::MCH_KEY));
 		}
 		$iv = mcrypt_create_iv(mcrypt_get_iv_size(self::CIPHER, self::MCRYPT_MODE), MCRYPT_RAND);
-		$decrypted = mcrypt_decrypt(self::CIPHER, $md5LowerKey, $encryptData, self::MCRYPT_MODE, $iv);
+		$decrypted = mcrypt_decrypt(self::CIPHER, $md5LowerKey, $encryptData_debase64, self::MCRYPT_MODE, $iv);
 		return $this->xml2array($decrypted);
 	}
 }

--- a/WxpayRefundNotifyHelper.php
+++ b/WxpayRefundNotifyHelper.php
@@ -34,7 +34,7 @@ class WxpayRefundNotifyHelper
 			$xml = file_get_contents("php://input");
 			$data = $this->xml2array($xml);
 			$encryptData = $data['req_info'];
-			$decryptedData = $this->xml2array($this->decryptData($encryptData,$this->MCH_KEY));
+			$decryptedData = $this->xml2array($this->decryptData($encryptData, self::MCH_KEY));
 			$msg = 'OK';
 			$result = $this->handelInternal($decryptedData, $msg);
 			$returnArray['return_msg'] = $msg;


### PR DESCRIPTION
根据反馈，mcrypt_decrypt在php7.1中已经废弃。
改为更加安全的openssl_decrypt方法。php需要加载openssl插件。